### PR TITLE
Update create-instances.yml

### DIFF
--- a/create-instances.yml
+++ b/create-instances.yml
@@ -73,6 +73,24 @@
       - "3" 
     register: hadoop_worker_values
 
+- name: Start ATBD-client instance
+  amazon.aws.ec2_instance:
+    name: "ATBD-client"
+    key_name: "vockey"
+    instance_type: t3.large
+    security_group: hadoop-sg
+    image_id: ami-066784287e358dad1
+    region: us-east-1
+    state: running
+    tags:
+      Group: ATBD-client
+    volumes:
+    - device_name: /dev/xvda
+      ebs:
+        volume_size: 50
+        delete_on_termination: true
+  register: atbd_client_values
+
   - meta: refresh_inventory
 
 - hosts: localhost
@@ -286,3 +304,29 @@
   #     device_id: "{{ item }}"
   #     region: us-east-1
   #   loop: "{{ hadoop_master_values.instance_ids }}"
+
+- hosts: tag_Group_ATBD-client
+  tasks:
+    - name: Install Python and PIP
+      ansible.builtin.yum:
+        name:
+          - python3
+          - python3-pip
+        state: present
+
+    - name: Install PySpark
+      ansible.builtin.pip:
+        name: pyspark
+
+    - name: Copy Hadoop configuration files from master
+      ansible.builtin.command: |
+        scp -i ~/.ssh/vockey ec2-user@{{ hadoop_master_values.instances[0].private_ip_address }}:/home/ec2-user/hadoop-3.3.6/etc/hadoop/core-site.xml /home/ec2-user/
+        scp -i ~/.ssh/vockey ec2-user@{{ hadoop_master_values.instances[0].private_ip_address }}:/home/ec2-user/hadoop-3.3.6/etc/hadoop/hdfs-site.xml /home/ec2-user/
+
+    - name: Set environment variables for Hadoop
+      ansible.builtin.shell: |
+        echo 'export HADOOP_CONF_DIR=/home/ec2-user/' >> ~/.bashrc
+        echo 'export PATH=$PATH:/home/ec2-user/hadoop-3.3.6/bin' >> ~/.bashrc
+
+    - name: Validate HDFS connectivity
+      ansible.builtin.command: /home/ec2-user/hadoop-3.3.6/bin/hdfs dfs -ls /


### PR DESCRIPTION
This pull request includes changes to the `create-instances.yml` file to add a new instance and configure it with necessary software and settings. The most important changes are the addition of a new EC2 instance for the ATBD-client and the setup of Python, PySpark, and Hadoop configurations on this instance.

### Instance Addition and Configuration:

* Added a new EC2 instance named "ATBDClient" with specific configurations such as instance type, security group, and tags.
* Configured the ATBDClient instance to install Python, PIP, and PySpark.
* Added tasks to copy Hadoop configuration files from the master node to the ATBD-client instance.
* Set environment variables for Hadoop on the ATBD-client instance.
* Added a validation step to check HDFS connectivity from the ATBD-client instance.